### PR TITLE
feat: use content settings and fix phantom settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.4.1
+- Replaced: Use ContentSettings instead of a "proprietary" patch
+- Moved: Settings from GRAPHICS to PERFORMANCE
+- Fixed: Missing settings are now visible
+
 # 0.3.0 (Notest's Indirect Fork)
 - Added: ContentWarning plugin attribute and marked as VanillaCompatible
 - Added: Instance = this

--- a/PerformanceSettings.cs
+++ b/PerformanceSettings.cs
@@ -8,6 +8,7 @@ using Setting = Zorro.Settings.Setting;
 using PerformanceSettings.Settings.Type;
 using PerformanceSettings.Settings;
 using PerformanceSettings;
+using ContentSettings.API;
 // ReSharper disable InconsistentNaming
 
 namespace MoreSettings
@@ -48,7 +49,7 @@ namespace MoreSettings
             //addPatches(new ResetToDefault());
 
             harmony ??= new Harmony(MyPluginInfo.PLUGIN_GUID);
-            harmony.PatchAll(typeof(MainPatch));
+
             ApplyPatches();
         }
 
@@ -71,42 +72,14 @@ namespace MoreSettings
 
         public static void addSetting(Setting setting)
         {
+            SettingsLoader.RegisterSetting("PERFORMANCE", null, setting);
+
             additionalSettings.Add(setting);
         }
 
         internal static void addPatches(IPatch patch)
         {
             patches.Add(patch);
-        }
-    }
-
-    internal class MainPatch
-    {
-
-        [HarmonyPatch(typeof(SettingsHandler),MethodType.Constructor)]
-        [HarmonyPostfix]
-        static void PatchSettingsHandler(SettingsHandler __instance)
-        {
-            var settings = Traverse.Create(__instance).Field("settings").GetValue() as List<Setting>;
-            var settingsSaveLoad = Traverse.Create(__instance).Field("_settingsSaveLoad").GetValue() as ISettingsSaveLoad;
-            settings = settings.Concat(PerformanceSettings.additionalSettings).ToList();
-            Traverse.Create(__instance).Field("settings").SetValue(settings);
-            foreach (Setting setting in PerformanceSettings.additionalSettings)
-            {
-                setting.Load(settingsSaveLoad);
-                setting.ApplyValue();
-            }
-            Debug.Log("Settings Patch Applied [MoreSettings]");
-        }
-
-        [HarmonyPatch(typeof(Player),"Start")]
-        [HarmonyPostfix]
-        static void ApplySettingAtStart(Player __instance)
-        {
-            if(__instance.IsLocal == true)
-            {
-                Tools.ApplySettings();
-            }
         }
     }
 }

--- a/PerformanceSettings.csproj
+++ b/PerformanceSettings.csproj
@@ -4,7 +4,7 @@
         <AssemblyName>Notest.PerformanceSettings</AssemblyName>
         <Product>PerformanceSettings</Product>
         <!-- Change to whatever version you're currently on. -->
-        <Version>0.3.0</Version>
+        <Version>0.4.1</Version>
     </PropertyGroup>
 
     <!-- Project Properties -->
@@ -51,6 +51,13 @@
 
     <ItemGroup Condition="'$(TargetFramework.TrimEnd(`0123456789`))' == 'net'">
         <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="all" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <Reference Include="CommanderCat101.ContentSettings">
+	      <HintPath>$(CW_References)..\..\BepInEx\plugins\CommanderCat101.ContentSettings.dll</HintPath>
+	      <Private>False</Private>
+      </Reference>
     </ItemGroup>
     
 </Project>

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# More Settings
-Adds performance settings such as graphics settings like render scale, FSR, texture resolution and etc.
+# Performance Settings
+Adds performance (and other QoL) settings such as render scale, FSR, texture resolution, more keybind remappings and etc.
 These settings can be use to lower the graphics settings of the game to obtain desired performance or better graphics.
 
-NOTE: these settings will impact both the camera and the player
+NOTE: these settings will impact both the camera and the player, I am unsure if that can be changed.
 
 ## Attributions
 This mod is an indirect fork of [MoreSettings](https://github.com/Jasson9/ContentWarning-MoreSettings) for Content Warning by [Jasson9](https://github.com/Jasson9) as it seemed to be unmaintained.

--- a/Settings/AimKeybindSetting.cs
+++ b/Settings/AimKeybindSetting.cs
@@ -1,9 +1,10 @@
-﻿using UnityEngine;
+﻿using ContentSettings.API.Settings;
+using UnityEngine;
 using Zorro.Settings;
 
 namespace PerformanceSettings.Settings
 {
-    internal class AimKeybindSetting : KeyCodeSetting, IExposedSetting
+    internal class AimKeybindSetting : KeyCodeSetting, ICustomSetting
     {
 
         public string GetDisplayName()

--- a/Settings/AntiAliasingSetting.cs
+++ b/Settings/AntiAliasingSetting.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using ContentSettings.API.Settings;
 using UnityEngine.Rendering.Universal;
 using Zorro.Settings;
 using UnityEngine;
@@ -6,7 +7,7 @@ using UnityEngine;
 
 namespace PerformanceSettings.Settings
 {
-    public class AntiAliasingSetting : EnumSetting, IExposedSetting
+    public class AntiAliasingSetting : EnumSetting, ICustomSetting
     {
         public override void ApplyValue()
         {

--- a/Settings/CrouchingModeSetting.cs
+++ b/Settings/CrouchingModeSetting.cs
@@ -1,11 +1,12 @@
 ﻿using System.Collections.Generic;
+using ContentSettings.API.Settings;
 using Zorro.Settings;
 using HarmonyLib;
 using PerformanceSettings.Settings.Type;
 
 namespace PerformanceSettings.Settings
 {
-    public class CrouchingModeSetting : EnumSetting, IExposedSetting, IPatch
+    public class CrouchingModeSetting : EnumSetting, ICustomSetting, IPatch
     {
         public override void ApplyValue()
         {

--- a/Settings/FOVSetting.cs
+++ b/Settings/FOVSetting.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using ContentSettings.API.Settings;
 using Unity.Mathematics;
 using Zorro.Settings;
 using PerformanceSettings.Settings.Type;
@@ -7,7 +8,7 @@ using UnityEngine;
 
 namespace PerformanceSettings.Settings
 {
-    public class FOVSetting : FloatSetting, IExposedSetting, IPatch
+    public class FOVSetting : FloatSetting, ICustomSetting, IPatch
     {
         static Traverse<float> baseFOVTraverse = null;
 

--- a/Settings/FSRSharpnessSetting.cs
+++ b/Settings/FSRSharpnessSetting.cs
@@ -2,10 +2,11 @@
 using UnityEngine.Rendering.Universal;
 using UnityEngine.Rendering;
 using Zorro.Settings;
+using ContentSettings.API.Settings;
 
 namespace PerformanceSettings.Settings
 {
-    public class FSRSharpnessSetting : FloatSetting, IExposedSetting
+    public class FSRSharpnessSetting : FloatSetting, ICustomSetting
     {
         public SettingCategory GetSettingCategory()
         {

--- a/Settings/FSRToggleSetting.cs
+++ b/Settings/FSRToggleSetting.cs
@@ -1,11 +1,12 @@
 ﻿using System.Collections.Generic;
+using ContentSettings.API.Settings;
 using UnityEngine.Rendering.Universal;
 using UnityEngine.Rendering;
 using Zorro.Settings;
 
 namespace PerformanceSettings.Settings
 {
-    public class FSRToggleSetting : EnumSetting, IExposedSetting
+    public class FSRToggleSetting : EnumSetting, ICustomSetting
     {
         public override void ApplyValue()
         {

--- a/Settings/HDRSetting.cs
+++ b/Settings/HDRSetting.cs
@@ -1,11 +1,12 @@
 ﻿using System.Collections.Generic;
+using ContentSettings.API.Settings;
 using UnityEngine.Rendering.Universal;
 using UnityEngine.Rendering;
 using Zorro.Settings;
 
 namespace PerformanceSettings.Settings
 {
-    public class HDRSetting : EnumSetting, IExposedSetting
+    public class HDRSetting : EnumSetting, ICustomSetting
     {
         public override void ApplyValue()
         {

--- a/Settings/PostProcessingSetting.cs
+++ b/Settings/PostProcessingSetting.cs
@@ -1,11 +1,12 @@
 ﻿using System.Collections.Generic;
+using ContentSettings.API.Settings;
 using UnityEngine.Rendering.Universal;
 using Zorro.Settings;
 using UnityEngine;
 
 namespace PerformanceSettings.Settings
 {
-    public class PostProcessingSetting : EnumSetting, IExposedSetting
+    public class PostProcessingSetting : EnumSetting, ICustomSetting
     {
         public override void ApplyValue()
         {

--- a/Settings/RenderScaleSetting.cs
+++ b/Settings/RenderScaleSetting.cs
@@ -2,10 +2,11 @@
 using UnityEngine.Rendering.Universal;
 using UnityEngine.Rendering;
 using Zorro.Settings;
+using ContentSettings.API.Settings;
 
 namespace PerformanceSettings.Settings
 {
-    public class RenderScaleSetting : FloatSetting, IExposedSetting
+    public class RenderScaleSetting : FloatSetting, ICustomSetting
     {
         public SettingCategory GetSettingCategory()
         {

--- a/Settings/ResetAudioToDefault.cs
+++ b/Settings/ResetAudioToDefault.cs
@@ -5,11 +5,13 @@ using Zorro.Settings;
 using UnityEngine;
 using TMPro;
 using System.Reflection;
+using ContentSettings.API.Settings;
 using Zorro.UI;
+using IntSetting = Zorro.Settings.IntSetting;
 
 namespace PerformanceSettings.Settings
 {
-    internal class ResetAudioToDefault : StringSetting, IExposedSetting, IPatch
+    internal class ResetAudioToDefault : StringSetting, ICustomSetting, IPatch
     {
         internal static TextMeshProUGUI titleComponent = null;
         internal static UIPageHandler pageHandler = null;

--- a/Settings/ResetControlsToDefault.cs
+++ b/Settings/ResetControlsToDefault.cs
@@ -5,11 +5,13 @@ using Zorro.Settings;
 using UnityEngine;
 using TMPro;
 using System.Reflection;
+using ContentSettings.API.Settings;
 using Zorro.UI;
+using IntSetting = Zorro.Settings.IntSetting;
 
 namespace PerformanceSettings.Settings
 {
-    internal class ResetControlsToDefault : StringSetting, IExposedSetting, IPatch
+    internal class ResetControlsToDefault : StringSetting, ICustomSetting, IPatch
     {
         internal static TextMeshProUGUI titleComponent = null;
         internal static UIPageHandler pageHandler = null;

--- a/Settings/ResetGraphicsToDefault.cs
+++ b/Settings/ResetGraphicsToDefault.cs
@@ -5,11 +5,13 @@ using Zorro.Settings;
 using UnityEngine;
 using TMPro;
 using System.Reflection;
+using ContentSettings.API.Settings;
 using Zorro.UI;
+using IntSetting = Zorro.Settings.IntSetting;
 
 namespace PerformanceSettings.Settings
 {
-    internal class ResetGraphicsToDefault: StringSetting, IExposedSetting, IPatch
+    internal class ResetGraphicsToDefault: StringSetting, ICustomSetting, IPatch
     {
         internal static TextMeshProUGUI titleComponent = null;
         internal static UIPageHandler pageHandler = null;

--- a/Settings/TextureResolutionSetting.cs
+++ b/Settings/TextureResolutionSetting.cs
@@ -1,10 +1,11 @@
 ﻿using System.Collections.Generic;
+using ContentSettings.API.Settings;
 using Zorro.Settings;
 using UnityEngine;
 
 namespace PerformanceSettings.Settings
 {
-    public class TextureResolutionSetting : EnumSetting, IExposedSetting
+    public class TextureResolutionSetting : EnumSetting, ICustomSetting
     {
         public override void ApplyValue()
         {

--- a/Settings/UseItemKeybindSetting.cs
+++ b/Settings/UseItemKeybindSetting.cs
@@ -1,11 +1,12 @@
-﻿using HarmonyLib;
+﻿using ContentSettings.API.Settings;
+using HarmonyLib;
 using PerformanceSettings.Settings.Type;
 using UnityEngine;
 using Zorro.Settings;
 
 namespace PerformanceSettings.Settings
 {
-    internal class UseItemKeybindSetting : KeyCodeSetting, IExposedSetting, IPatch
+    internal class UseItemKeybindSetting : KeyCodeSetting, ICustomSetting, IPatch
     {
         public void ApplyPatch(ref Harmony harmony)
         {


### PR DESCRIPTION
- Replaced: Use ContentSettings instead of a "proprietary" patch
- Moved: Settings from GRAPHICS to PERFORMANCE
- Fixed: Missing settings are now visible
Resolves #1 